### PR TITLE
Add /asx_cgt base path

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,5 @@ import react from "@vitejs/plugin-react";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: "/asx_cgt",
 });


### PR DESCRIPTION
# Description
Oversight from #2. Because this deploys to a sub-path on GH Pages the `base` needs to be set in the vite config to match the path it deploys to as per the [Vite docs](https://vitejs.dev/guide/static-deploy#github-pages)

This has been E2E tested with the same setup with my personal eddie-atkinson.github.io site. You can see: 
* The deployed version [here](https://eddie-atkinson.github.io/asx_cgt/) 
* The `release` branch's diff [here](https://github.com/eddie-atkinson/asx-cgt-calculator-optimiser/commit/edfe98185468d714310ccfac45f2b9c713be9c4d)
* The corresponding GH actions runs [here](https://github.com/eddie-atkinson/asx-cgt-calculator-optimiser/actions/runs/10683941572/job/29613178480) on my push to `release` and [here](https://github.com/eddie-atkinson/eddie-atkinson.github.io/actions/runs/10683916485) on my `eddie-atkinson.github.io` repo